### PR TITLE
Add timestamp to generated files

### DIFF
--- a/sphinxcontrib/autodoc_doxygen/autosummary/generate.py
+++ b/sphinxcontrib/autodoc_doxygen/autosummary/generate.py
@@ -4,6 +4,7 @@ import codecs
 import os
 import re
 import sys
+import datetime
 
 from jinja2 import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
@@ -109,6 +110,7 @@ def generate_autosummary_docs(sources, output_dir=None, suffix='.rst',
 
             rendered = template.render(**ns)
             f.write(rendered)
+            f.write('\n..\n   {}'.format(datetime.datetime.now()))
 
     # descend recursively to new files
     if new_files:


### PR DESCRIPTION
To try to defeat RTD's caching, we add a timestamp to generated files so they're hopefully unconditionally rebuilt.